### PR TITLE
Added support for reactivation

### DIFF
--- a/lib/artifice.rb
+++ b/lib/artifice.rb
@@ -33,6 +33,11 @@ module Artifice
     replace_net_http(NET_HTTP)
   end
 
+  # Reactivate the last Artifice replacement
+  def self.reactivate(&block)
+    activate_with(Net::HTTP.endpoint, &block)
+  end
+
 private
   def self.replace_net_http(value)
     ::Net.class_eval do

--- a/spec/artifice_spec.rb
+++ b/spec/artifice_spec.rb
@@ -178,4 +178,32 @@ describe "Artifice" do
       }.should raise_error
     end
   end
+
+  describe Artifice, "#reactivate" do
+    
+    before do
+      @endpoint = lambda {|env| [ 200, {}, [] ] }
+
+      Artifice.activate_with @endpoint
+      Artifice::Net::HTTP.endpoint.should == @endpoint
+      ::Net::HTTP.should == Artifice::Net::HTTP
+
+      Artifice.deactivate
+      ::Net::HTTP.should == NET_HTTP
+    end
+
+    it "reactivates Artifice with the last endpoint that was used" do
+      Artifice.reactivate
+      Artifice::Net::HTTP.endpoint.should == @endpoint
+      ::Net::HTTP.should == Artifice::Net::HTTP
+    end
+
+    it "can reactivate within a block" do
+      Artifice.reactivate do
+        Artifice::Net::HTTP.endpoint.should == @endpoint
+        ::Net::HTTP.should == Artifice::Net::HTTP
+      end
+      ::Net::HTTP.should == NET_HTTP
+    end
+  end
 end


### PR DESCRIPTION
I added an Artifice.reactivate method. It supports the same style as activate_with, but just mounts the last used endpoint.

It may seem hard to justify, but this is actually really useful for (ahem) "a special case" we're dealing with in one of our suites and I suspect it could be useful for others as well.
